### PR TITLE
Adds sshfs & tmux related info

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ In your `Dockerfile`, if you are already installing packages through `apt`, simp
 
 Right when your docker image is spun up as a container on the DGX (i.e. right when your job starts), say you want a `tmux` session named `mysession` to start with three windows: **1)** `htop`, **2)** `watch -n1 nvidia-smi`, **3)** a regular terminal for you to do what you like. (It's possible to add more windows to an existing session)
 
-Place the following command at the end your `Dockerfile` (make sure this is not overriden elsewhere):
+Place the following command at the end your `Dockerfile` (make sure this is not overridden elsewhere):
 ```
 CMD tmux new-session -d -s mysession \; \
     send-keys 'htop' C-m \; \

--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ Now you can simply use the following command to mount the remote directory onto 
 ```sh
 sshfs username@10.1.115.65:/mnt/dgx_001/aiqu_data/users/username/ ~/mount/datafactory
 ```
-Replace in the command above `username` with your oru.se username. The password will also be your oru.se password,
+Replace in the command above `username` with your oru.se username. The password will also be your oru.se password. You can verify whether the mount was successful by running `mount | grep sshfs` which should produce:
+```
+username@10.1.115.65:/mnt/dgx_001/aiqu_data/users/username/ on /mount/datafactory type fuse.sshfs (rw,nosuid,nodev,relatime,user_id=1000,group_id=1000)
+```
 
 You can now use the mounted directory to transfer your prototype code and data to the Data Factory from your local machine.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Next you will want to mount your home directory on the Data Factory on to your l
 ```sh
 mkdir -p ~/mount/datafactory
 ```
-Now you can simply use the following command to mount the remote directory onto your local machine. Note that you need to be on the oru.se network for this (either physically or via VPN).
+Now you can simply use the following command to mount the remote directory onto your local machine ([sshfs](https://github.com/libfuse/sshfs) can be installed using `sudo apt install sshfs`). Note that you need to be on the oru.se network for this (either physically or via VPN).
 ```sh
 sshfs username@10.1.115.65:/mnt/dgx_001/aiqu_data/users/username/ ~/mount/datafactory
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can now use the mounted directory to transfer your prototype code and data t
 Note: if you have never logged in to the Data Factory, your personal directory does not exist yet. In this case you will first have to login using the webinterface. The steps are described in the next section. 
 
 ### 3. Running Code on the DGX Machine
- Let's assume you have some code and data in the `~/mount/datafactory/AGI` directroy and you want to run your algorithm on the DGX Machine now. Here is what you have to to.
+ Let's assume you have some code and data in the `~/mount/datafactory/AGI` directory and you want to run your algorithm on the DGX Machine now. Here is what you have to to.
 
  1. Go to [horizon.oru.se](https://horizon.oru.se/portal/webclient/#/launchitems), look for `oru.aiqu.se` and login. You will end up in a dashboard looking like this:
  ![image](images/dashboard.png)
@@ -74,7 +74,7 @@ Note: if you have never logged in to the Data Factory, your personal directory d
 
     You are now good to go. Click on `Queue Job` and wait for your job to be scheduled.
 
-    Once this happens, open a terminal for your job (on the far right in the job list). List the files and directories (`ls`). Your project should now be in the `AGI` directroy. You can cd into it and run your algorithm
+    Once this happens, open a terminal for your job (on the far right in the job list). List the files and directories (`ls`). Your project should now be in the `AGI` directory. You can cd into it and run your algorithm
     ```sh
     cd AGI
     python agi.py

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ sudo apt update && sudo apt install tmux
 In your `Dockerfile`, if you are already installing packages through `apt`, simply throw in `tmux` and it will get installed in your docker image.
 
 #### How to use?
+(a good video to start with is [Fireship: Tmux in 100 seconds](https://youtu.be/vtB1J_zCv8I))
+
 Right when your docker image is spun up as a container on the DGX (i.e. right when your job starts), say you want a `tmux` session named `mysession` to start with three windows: **1)** `htop`, **2)** `watch -n1 nvidia-smi`, **3)** a regular terminal for you to do what you like. (It's possible to add more windows to an existing session)
 
 Place the following command at the end your `Dockerfile` (make sure this is not overriden elsewhere):
@@ -123,5 +125,3 @@ All keyboard shortcuts for interacting with a `tmux` session _start_ with `Ctrl 
 1. `W`: Brings up list of windows in the session. Use arrow keys to reach a window and hit `enter` to select it.
 2. `0-9`: Directly brings up the window matching the index number without requiring to go to the list of windows first.
 3. `[`: Activates scroll mode _inside a window_. Use up-down direction keys to scroll, and `Page Up/Down` to jump a page. Hit `q` to deactivate scroll mode.
-
-If you have made it this far, make sure to check out [Fireship: Tmux in 100 seconds](https://youtu.be/vtB1J_zCv8I).


### PR DESCRIPTION
Main changes:
- Install instructions for `sshfs` (Ubuntu 22.04 doesn't already come with `sshfs`, not sure of other versions)
- Verification that remote directory was mounted successfully, because `sshfs` is silent after mounting.
- Fixed minor typo.
- New section on how to install and use `tmux` to not lose logs.